### PR TITLE
Remove trailing commas in CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,13 +9,13 @@
       "installDir": "${sourceDir}/out/install/${presetName}",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "cl.exe",
-        "CMAKE_CXX_COMPILER": "cl.exe",
+        "CMAKE_CXX_COMPILER": "cl.exe"
       },
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
-      },
+      }
     },
     {
       "name": "windows-clang-base",


### PR DESCRIPTION
They're non-standard JSON, and causes cmake to fail on Linux. With this change,  `cmake --preset=linux-release` followed by `cmake --build out/build/linux-release` successfully gets a compilation error on Linux.